### PR TITLE
fix(ci): execute PostgreSQL ALTER SYSTEM commands separately

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -56,17 +56,15 @@ jobs:
           echo "Waiting for PostgreSQL..."
           sleep 2
         done
-        # Configure PostgreSQL for better test performance
-        psql -h localhost -p 5432 -U postgres -d test_db -c "
-          ALTER SYSTEM SET fsync = off;
-          ALTER SYSTEM SET full_page_writes = off;
-          ALTER SYSTEM SET synchronous_commit = off;
-          ALTER SYSTEM SET checkpoint_segments = 32;
-          ALTER SYSTEM SET checkpoint_completion_target = 0.9;
-          ALTER SYSTEM SET wal_buffers = '16MB';
-          ALTER SYSTEM SET shared_buffers = '256MB';
-          SELECT pg_reload_conf();
-        "
+        # Configure PostgreSQL for better test performance (separate commands to avoid transaction wrapping)
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET fsync = off"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET full_page_writes = off"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET synchronous_commit = off"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET checkpoint_segments = 32"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET checkpoint_completion_target = 0.9"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET wal_buffers = '16MB'"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET shared_buffers = '256MB'"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "SELECT pg_reload_conf()"
       env:
         PGPASSWORD: postgres
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -56,17 +56,15 @@ jobs:
           echo "Waiting for PostgreSQL..."
           sleep 2
         done
-        # Configure PostgreSQL for better test performance
-        psql -h localhost -p 5432 -U postgres -d test_db -c "
-          ALTER SYSTEM SET fsync = off;
-          ALTER SYSTEM SET full_page_writes = off;
-          ALTER SYSTEM SET synchronous_commit = off;
-          ALTER SYSTEM SET checkpoint_segments = 32;
-          ALTER SYSTEM SET checkpoint_completion_target = 0.9;
-          ALTER SYSTEM SET wal_buffers = '16MB';
-          ALTER SYSTEM SET shared_buffers = '256MB';
-          SELECT pg_reload_conf();
-        "
+        # Configure PostgreSQL for better test performance (separate commands to avoid transaction wrapping)
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET fsync = off"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET full_page_writes = off"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET synchronous_commit = off"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET checkpoint_segments = 32"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET checkpoint_completion_target = 0.9"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET wal_buffers = '16MB'"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET shared_buffers = '256MB'"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "SELECT pg_reload_conf()"
       env:
         PGPASSWORD: postgres
 

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -56,17 +56,15 @@ jobs:
           echo "Waiting for PostgreSQL..."
           sleep 2
         done
-        # Configure PostgreSQL for better test performance
-        psql -h localhost -p 5432 -U postgres -d test_db -c "
-          ALTER SYSTEM SET fsync = off;
-          ALTER SYSTEM SET full_page_writes = off;
-          ALTER SYSTEM SET synchronous_commit = off;
-          ALTER SYSTEM SET checkpoint_segments = 32;
-          ALTER SYSTEM SET checkpoint_completion_target = 0.9;
-          ALTER SYSTEM SET wal_buffers = '16MB';
-          ALTER SYSTEM SET shared_buffers = '256MB';
-          SELECT pg_reload_conf();
-        "
+        # Configure PostgreSQL for better test performance (separate commands to avoid transaction wrapping)
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET fsync = off"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET full_page_writes = off"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET synchronous_commit = off"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET checkpoint_segments = 32"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET checkpoint_completion_target = 0.9"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET wal_buffers = '16MB'"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET shared_buffers = '256MB'"
+        psql -h localhost -p 5432 -U postgres -d test_db -c "SELECT pg_reload_conf()"
       env:
         PGPASSWORD: postgres
 

--- a/.github/workflows/test-db-setup.sql
+++ b/.github/workflows/test-db-setup.sql
@@ -1,5 +1,13 @@
 -- PostgreSQL performance optimization script for CI testing
 -- This file contains the SQL commands used to optimize PostgreSQL for CI testing
+--
+-- IMPORTANT: These commands must be executed separately (not in a transaction block)
+-- because ALTER SYSTEM cannot run inside a transaction.
+--
+-- Usage in CI workflows:
+-- psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET fsync = off"
+-- psql -h localhost -p 5432 -U postgres -d test_db -c "ALTER SYSTEM SET full_page_writes = off"
+-- ... (each command separately)
 
 -- Disable fsync for faster writes (safe for test environments)
 ALTER SYSTEM SET fsync = off;


### PR DESCRIPTION
Fixed "ALTER SYSTEM cannot run inside a transaction block" error by executing each ALTER SYSTEM command in separate psql calls instead of combining them in a single multi-statement command. PostgreSQL wraps multi-statement commands in implicit transactions, which prevents ALTER SYSTEM from executing.

Changes:
- Split PostgreSQL configuration into individual psql commands
- Updated all three CI workflows (develop, staging, main)
- Added documentation notes to test-db-setup.sql