### PR TITLE
chore: Standardize CI workflow PR titles and bodies

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -73,11 +73,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITOPS_PAT }}
           PR_BODY: |
-            Automated deployment of purchaseorder-service to development environment.
+            Automated GitOps Update
 
-            Commit: ${{ github.sha }}
+            - **Service**: PurchaseOrderService
+            - **Environment**: Development
+            - **Image Tag**: ${{ github.sha }}
+            - **Source Branch**: ${{ github.ref_name }}
+            - **Commit**: ${{ github.sha }}
+
+            Updates maliev-purchaseorder-service image in development overlay.
+            This PR was automatically created by GitHub Actions.
+            Once merged, ArgoCD will automatically sync the changes to the maliev-dev namespace.
+
             Triggered by: ${{ github.actor }}
             Workflow: ${{ github.workflow }}
+            Run: [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
         run: |
           cd maliev-gitops
           git config --global user.name 'github-actions[bot]'
@@ -94,8 +104,13 @@ jobs:
             exit 0
           fi
 
-          git commit -m "Update purchaseorder-service image to ${{ github.sha }}"
+          git commit -m "chore(dev): Update PurchaseOrderService image to ${{ github.sha }}"
           git push origin $BRANCH_NAME
 
           # Create pull request using GitHub CLI
-          gh pr create             --title "Deploy purchaseorder-service ${{ github.sha }} to development"             --body "$PR_BODY"             --base main             --head $BRANCH_NAME             --repo MALIEV-Co-Ltd/maliev-gitops
+          gh pr create \
+            --title "chore(dev): Update purchaseorder-service" \
+            --body "$PR_BODY" \
+            --base main \
+            --head $BRANCH_NAME \
+            --repo MALIEV-Co-Ltd/maliev-gitops

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -74,13 +74,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITOPS_PAT }}
           PR_BODY: |
-            Automated deployment of purchaseorder-service to production environment.
+            Automated GitOps Update - **PRODUCTION**
 
-            **PRODUCTION DEPLOYMENT** - Please review carefully before merging.
+            - **Service**: PurchaseOrderService
+            - **Environment**: Production
+            - **Image Tag**: ${{ github.sha }}
+            - **Source Branch**: ${{ github.ref_name }}
+            - **Commit**: ${{ github.sha }}
 
-            Commit: ${{ github.sha }}
+            Updates maliev-purchaseorder-service image in production overlay.
+            **WARNING**: This is a production deployment and should be reviewed before merging.
+            This PR was automatically created by GitHub Actions.
+            Once merged, ArgoCD will automatically sync the changes to the maliev-prod namespace.
+
             Triggered by: ${{ github.actor }}
             Workflow: ${{ github.workflow }}
+            Run: [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
         run: |
           cd maliev-gitops
           git config --global user.name 'github-actions[bot]'
@@ -97,8 +106,13 @@ jobs:
             exit 0
           fi
 
-          git commit -m "Update purchaseorder-service image to ${{ github.sha }}"
+          git commit -m "chore(prod): Update PurchaseOrderService image to ${{ github.sha }}"
           git push origin $BRANCH_NAME
 
           # Create pull request using GitHub CLI
-          gh pr create             --title "Deploy purchaseorder-service ${{ github.sha }} to production"             --body "$PR_BODY"             --base main             --head $BRANCH_NAME             --repo MALIEV-Co-Ltd/maliev-gitops
+          gh pr create \
+            --title "chore(prod): Update purchaseorder-service" \
+            --body "$PR_BODY" \
+            --base main \
+            --head $BRANCH_NAME \
+            --repo MALIEV-Co-Ltd/maliev-gitops

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -79,12 +79,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITOPS_PAT }}
           PR_BODY: |
-            Automated deployment of purchase-order-service to staging environment.
+            Automated GitOps Update
 
-            Release: $RELEASE_VERSION
-            Tag: ${{ github.ref }}
+            - **Service**: PurchaseOrderService
+            - **Environment**: Staging
+            - **Release**: ${{ github.ref_name }}
+            - **Image Tag**: ${{ github.ref_name }}
+            - **Commit**: ${{ github.sha }}
+
+            Updates maliev-purchase-order-service image in staging overlay.
+            This PR was automatically created by GitHub Actions.
+            Once merged, ArgoCD will automatically sync the changes to the maliev-staging namespace.
+
             Triggered by: ${{ github.actor }}
             Workflow: ${{ github.workflow }}
+            Run: [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
         run: |
           cd maliev-gitops
           git config --global user.name 'github-actions[bot]'
@@ -104,12 +113,12 @@ jobs:
             exit 0
           fi
 
-          git commit -m "Update purchase-order-service image to $RELEASE_VERSION"
+          git commit -m "chore(staging): Update PurchaseOrderService image to $RELEASE_VERSION"
           git push origin $BRANCH_NAME
 
           # Create pull request using GitHub CLI
           gh pr create \
-            --title "Deploy purchase-order-service $RELEASE_VERSION to staging" \
+            --title "chore(staging): Update purchase-order-service" \
             --body "$PR_BODY" \
             --base main \
             --head $BRANCH_NAME \


### PR DESCRIPTION
This PR standardizes the CI workflows across the service to use consistent branch-aware PR titles and detailed, multiline PR bodies for better readability and traceability in GitOps updates.

Changes:
- Standardized PR titles to \chore(<env>): Update <service-name>\
- Implemented multiline PR bodies with service, environment, image tag, and workflow details.
- Added production warning for main branch deployments.