### PR TITLE
Configure Dependabot update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: /Maliev.PurchaseOrderService.Api
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- configure only detected dependency ecosystems
- limit NuGet/npm queues to 10 and Docker/Actions queues to 5
- group minor and patch updates while leaving majors separate
- keep updates review-gated with no auto-merge

## Validation
- NuGet and Docker policy; YAML parse; Release tests
- git diff --check

No runtime, infrastructure, or deployment behavior changes.